### PR TITLE
feat: override exclude-newer for known security fixes

### DIFF
--- a/.github/workflows/security-updates.yml
+++ b/.github/workflows/security-updates.yml
@@ -116,10 +116,11 @@ jobs:
           done > /tmp/before_versions.txt
 
           # Run upgrades: pin to fix version when known, upgrade to latest when unknown
+          now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           jq -r '.[] | .name + "\t" + (.fixed // "")' /tmp/grouped.json | while IFS=$'\t' read pkg fixed; do
             if [[ -n "$fixed" ]]; then
-              echo "Upgrading $pkg to $fixed..."
-              uv lock --upgrade-package "$pkg==$fixed"
+              echo "Upgrading $pkg to $fixed (overriding exclude-newer)..."
+              uv lock --upgrade-package "$pkg==$fixed" --exclude-newer "$now"
             else
               echo "Upgrading $pkg to latest (fix version unknown)..."
               uv lock --upgrade-package "$pkg"

--- a/security-updates/update.py
+++ b/security-updates/update.py
@@ -20,6 +20,7 @@ import subprocess
 import sys
 import tomllib
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -178,14 +179,20 @@ def upgrade_packages(packages: list[VulnerablePackage], lockfile: Path) -> dict[
     """
     versions: dict[str, tuple[str, str]] = {}
 
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
     for pkg in packages:
         before = read_version(pkg.name, lockfile)
         if pkg.fixed:
             specifier = f"{pkg.name}=={pkg.fixed}"
+            # Override exclude-newer so verified security fixes are never blocked
+            cmd = ["uv", "lock", "--upgrade-package", specifier, "--exclude-newer", now]
         else:
             specifier = pkg.name
+            # Respect exclude-newer when upgrading to latest (no verified fix version)
+            cmd = ["uv", "lock", "--upgrade-package", specifier]
         print(f"Upgrading {pkg.name} (current: {before}, target: {pkg.fixed or 'latest'})...")
-        result = run(["uv", "lock", "--upgrade-package", specifier], check=False)
+        result = run(cmd, check=False)
         if result.returncode != 0:
             print(f"  Warning: uv lock failed for {pkg.name}: {result.stderr.strip()}")
         after = read_version(pkg.name, lockfile)


### PR DESCRIPTION
## Summary

When a repo has `exclude-newer` configured in `[tool.uv]` (e.g. `exclude-newer = "7 days"` to mitigate supply chain attacks), it can block legitimate security fixes from being installed.

This PR overrides `exclude-newer` by passing `--exclude-newer` with the current timestamp **only** when the fix version is known (verified by Dependabot). When the fix version is unknown and we fall back to upgrading to latest, `exclude-newer` is respected as normal.

**Rationale:** Dependabot-reported fix versions are tied to verified CVEs/GHSAs — they're known, trusted packages. The `exclude-newer` window protects against *unknown* supply chain threats, not against installing a verified security patch. Overriding it for targeted, known fixes is safe.

### Changes

- **Python script (`update.py`)**: pass `--exclude-newer <now>` when `pkg.fixed` is set
- **Reusable workflow (`security-updates.yml`)**: same logic using `date -u`
- Unknown fix versions still respect `exclude-newer` (fall back to `uv lock --upgrade-package <pkg>` without override)

## Test plan

- [ ] Verify that a repo with `exclude-newer = "7 days"` can now upgrade to a known fix version published within the window
- [ ] Verify that unknown-fix upgrades still respect `exclude-newer`

https://claude.ai/code/session_01Puvo1JnTpLGhDuDHrn9zf9