### PR TITLE
fix: use --exclude-newer-package to preserve lockfile span

### DIFF
--- a/.github/workflows/security-updates.yml
+++ b/.github/workflows/security-updates.yml
@@ -119,8 +119,8 @@ jobs:
           now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           jq -r '.[] | .name + "\t" + (.fixed // "")' /tmp/grouped.json | while IFS=$'\t' read pkg fixed; do
             if [[ -n "$fixed" ]]; then
-              echo "Upgrading $pkg to $fixed (overriding exclude-newer)..."
-              uv lock --upgrade-package "$pkg==$fixed" --exclude-newer "$now"
+              echo "Upgrading $pkg to $fixed (overriding exclude-newer for this package)..."
+              uv lock --upgrade-package "$pkg==$fixed" --exclude-newer-package "$pkg=$now"
             else
               echo "Upgrading $pkg to latest (fix version unknown)..."
               uv lock --upgrade-package "$pkg"

--- a/security-updates/update.py
+++ b/security-updates/update.py
@@ -233,8 +233,12 @@ def upgrade_packages(packages: list[VulnerablePackage], lockfile: Path) -> dict[
         before = read_version(pkg.name, lockfile)
         if pkg.fixed:
             specifier = f"{pkg.name}=={pkg.fixed}"
-            # Override exclude-newer so verified security fixes are never blocked
-            cmd = ["uv", "lock", "--upgrade-package", specifier, "--exclude-newer", now]
+            # Override exclude-newer for this package only so the global
+            # exclude-newer / exclude-newer-span in the lockfile is preserved.
+            cmd = [
+                "uv", "lock", "--upgrade-package", specifier,
+                "--exclude-newer-package", f"{pkg.name}={now}",
+            ]
         else:
             specifier = pkg.name
             # Respect exclude-newer when upgrading to latest (no verified fix version)


### PR DESCRIPTION
## Summary

- Fixes CI failures caused by #7 — `--exclude-newer` overwrites the global `exclude-newer-span` in `uv.lock`, making `uv sync --locked` fail because the lockfile no longer matches `exclude-newer = "7 days"` in `pyproject.toml`
- Switches to `--exclude-newer-package` which applies the override per-package only, preserving the global `exclude-newer` / `exclude-newer-span` metadata

## Test plan

- [ ] Trigger Security Updates workflow on a repo with `exclude-newer = "7 days"` — verify the lockfile keeps `exclude-newer-span = "P7D"`
- [ ] Verify `uv sync --locked` passes after the security PR is merged