### PR TITLE
feat: add uv-version parameter to security-updates action

### DIFF
--- a/security-updates/action.yml
+++ b/security-updates/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: Title for the PR
     required: false
     default: "security: upgrade vulnerable dependencies"
+  uv-version:
+    description: uv version to install
+    required: false
+    default: latest
 
 runs:
   using: composite
@@ -30,6 +34,8 @@ runs:
         client-id: ${{ inputs.app-id }}
         private-key: ${{ inputs.private-key }}
     - uses: astral-sh/setup-uv@v7
+      with:
+        version: ${{ inputs.uv-version }}
     - name: Configure git with app token
       shell: bash
       run: |


### PR DESCRIPTION
## Summary

- Add a `uv-version` input to the `security-updates` composite action, defaulting to `latest`.
- Pass it through to `astral-sh/setup-uv@v7` via its `version` input, so callers can pin uv to a specific version for reproducible runs.

## Test plan

- [ ] Merge and wire up `uv-version: "0.11.7"` in `Komorebi-AI/eurofunding` PR #215 to verify the input is honored.