### PR TITLE
feat(prek): add ruff version sync check

### DIFF
--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -15,6 +15,16 @@ on:
         required: false
         type: string
         default: '--all-files'
+      skip-hooks:
+        required: false
+        type: string
+        default: ''
+        description: 'Comma-separated hook IDs to skip (passed to prek via the SKIP env var)'
+      check-ruff-version:
+        required: false
+        type: boolean
+        default: false
+        description: 'Verify the ruff version in uv.lock matches the ruff-pre-commit rev in .pre-commit-config.yaml'
       debug-enabled:
         required: false
         type: boolean
@@ -63,7 +73,23 @@ jobs:
           cache-dependency-glob: uv.lock
       - name: Install the project
         run: uv sync --locked --dev --all-extras
+      - name: Check ruff versions are in sync
+        if: ${{ inputs.check-ruff-version }}
+        run: |
+          LOCK_VER=$(awk '/^name = "ruff"$/{getline; if ($1 == "version") {gsub(/"/, "", $3); print $3; exit}}' uv.lock)
+          CONFIG_VER=$(grep -A2 'ruff-pre-commit' .pre-commit-config.yaml | grep 'rev:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          if [ -z "$LOCK_VER" ] || [ -z "$CONFIG_VER" ]; then
+            echo "::error::Could not extract ruff version (uv.lock=$LOCK_VER, .pre-commit-config.yaml=$CONFIG_VER)"
+            exit 1
+          fi
+          if [ "$LOCK_VER" != "$CONFIG_VER" ]; then
+            echo "::error::Ruff version mismatch: uv.lock=$LOCK_VER, .pre-commit-config.yaml=$CONFIG_VER"
+            exit 1
+          fi
+          echo "Ruff versions in sync: $LOCK_VER"
       - name: Run prek
         uses: j178/prek-action@v2
         with:
           extra-args: ${{ inputs.prek-args }}
+        env:
+          SKIP: ${{ inputs.skip-hooks }}

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -23,8 +23,8 @@ on:
       check-ruff-version:
         required: false
         type: boolean
-        default: false
-        description: 'Verify the ruff version in uv.lock matches the ruff-pre-commit rev in .pre-commit-config.yaml'
+        default: true
+        description: 'Verify the ruff version in uv.lock matches the ruff-pre-commit rev in .pre-commit-config.yaml. Auto-skipped if either file does not reference ruff.'
       debug-enabled:
         required: false
         type: boolean
@@ -76,10 +76,14 @@ jobs:
       - name: Check ruff versions are in sync
         if: ${{ inputs.check-ruff-version }}
         run: |
-          LOCK_VER=$(awk '/^name = "ruff"$/{getline; if ($1 == "version") {gsub(/"/, "", $3); print $3; exit}}' uv.lock)
-          CONFIG_VER=$(grep -A2 'ruff-pre-commit' .pre-commit-config.yaml | grep 'rev:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          LOCK_VER=$(awk '/^name = "ruff"$/{getline; if ($1 == "version") {gsub(/"/, "", $3); print $3; exit}}' uv.lock 2>/dev/null || true)
+          CONFIG_VER=$(grep -A2 'ruff-pre-commit' .pre-commit-config.yaml 2>/dev/null | grep 'rev:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)
+          if [ -z "$LOCK_VER" ] && [ -z "$CONFIG_VER" ]; then
+            echo "No ruff in uv.lock or ruff-pre-commit in .pre-commit-config.yaml; skipping check."
+            exit 0
+          fi
           if [ -z "$LOCK_VER" ] || [ -z "$CONFIG_VER" ]; then
-            echo "::error::Could not extract ruff version (uv.lock=$LOCK_VER, .pre-commit-config.yaml=$CONFIG_VER)"
+            echo "::error::Ruff is configured in only one place (uv.lock=$LOCK_VER, .pre-commit-config.yaml=$CONFIG_VER); they must match."
             exit 1
           fi
           if [ "$LOCK_VER" != "$CONFIG_VER" ]; then

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -15,11 +15,6 @@ on:
         required: false
         type: string
         default: '--all-files'
-      check-ruff-version:
-        required: false
-        type: boolean
-        default: true
-        description: 'Verify the ruff version in uv.lock matches the ruff-pre-commit rev in .pre-commit-config.yaml. Auto-skipped if either file does not reference ruff.'
       debug-enabled:
         required: false
         type: boolean
@@ -69,7 +64,6 @@ jobs:
       - name: Install the project
         run: uv sync --locked --dev --all-extras
       - name: Check ruff versions are in sync
-        if: ${{ inputs.check-ruff-version }}
         run: |
           LOCK_VER=$(awk '/^name = "ruff"$/{getline; if ($1 == "version") {gsub(/"/, "", $3); print $3; exit}}' uv.lock 2>/dev/null || true)
           CONFIG_VER=$(grep -A2 'ruff-pre-commit' .pre-commit-config.yaml 2>/dev/null | grep 'rev:' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)

--- a/.github/workflows/prek.yml
+++ b/.github/workflows/prek.yml
@@ -15,11 +15,6 @@ on:
         required: false
         type: string
         default: '--all-files'
-      skip-hooks:
-        required: false
-        type: string
-        default: ''
-        description: 'Comma-separated hook IDs to skip (passed to prek via the SKIP env var)'
       check-ruff-version:
         required: false
         type: boolean
@@ -95,5 +90,3 @@ jobs:
         uses: j178/prek-action@v2
         with:
           extra-args: ${{ inputs.prek-args }}
-        env:
-          SKIP: ${{ inputs.skip-hooks }}


### PR DESCRIPTION
## Summary
Add an always-on ruff version sync check to the reusable `prek.yml` workflow.

After the prek dependencies are installed, a step compares the ruff version resolved in `uv.lock` against the `rev:` pinned under `ruff-pre-commit` in `.pre-commit-config.yaml`:

- both present and matching → pass
- both present and mismatched → fail with a clear `::error::`
- configured in only one file → fail (they must stay in sync)
- neither file references ruff → silently skip

No new inputs. Workflows that opt in to the reusable workflow get the check automatically.

## Motivation
This is the customization that kept `Komorebi-AI/eurofunding` from using the reusable workflow after its pre-commit -> prek migration (see eurofunding#220). Baking the check into the reusable workflow means callers no longer need bespoke logic, and any repo on this workflow gets protection against ruff/ruff-pre-commit drift for free.

Skipping hooks in CI was also considered as a separate input but is unnecessary: prek's \`--skip <hook-id>\` CLI flag is repeatable and composes with whatever the caller passes via \`prek-args\` (e.g. \`prek-args: --all-files --skip sqlfluff-lint --skip sqlfluff-fix\`). See sumauto-datalake#510.

## Better alternative: a pre-commit hook in each repo
This CI check catches drift after the fact. A pre-commit hook would *auto-fix* the config whenever \`uv.lock\` changes, making the CI check redundant. Two candidates:

- [**tsvikas/sync-with-uv**](https://github.com/tsvikas/sync-with-uv) — 81 stars, ~9.5k PyPI downloads/month, last release 2025-11-18 (v0.5.0), ~21 commits in the last 90 days. Focused scope (uv ↔ pre-commit), strongest adoption and momentum; young repo (~14 months), single primary maintainer.
- [**GabDug/sync-pre-commit-lock**](https://github.com/GabDug/sync-pre-commit-lock) — 30 stars, ~520 PyPI downloads/month, last release 2026-03-14 (v0.9.0), 25 releases since 2023. Broader PDM/Poetry/UV scope, slower cadence but the longest track record.

Prek shouldn't affect either — they're config rewriters, not tied to the runner.

Recommendation: land this CI check now. Long-term, add one of the two hooks above to [\`python-copier-template\`](https://github.com/Komorebi-AI/python-copier-template) so every new repo gets automatic syncing and this CI check becomes a safety net rather than the primary defence.

## Known drift in python-copier-template
\`python-copier-template/.pre-commit-config.yaml.jinja\` pins \`ruff-pre-commit\` at \`rev: v0.12.4\` while \`pyproject.toml.jinja\` leaves \`ruff\` unpinned in dev deps — every repo generated from the template is shipped already misaligned (latest ruff is well past v0.12.4), and the rev only advances when someone remembers to bump it in the template. Adding a sync hook to the template would fix this at the source.

## Test plan
- [ ] Call from a repo with matching ruff versions → step passes.
- [ ] Deliberately mismatch the versions → step fails with a clear error.
- [ ] Call from a repo with neither ruff in \`uv.lock\` nor \`ruff-pre-commit\` in the config → step logs a skip message and passes.
- [ ] Call from a repo with ruff in only one of the two files → step fails.