### PR TITLE
fix: group security alerts by normalized name and link to GHSA pages

### DIFF
--- a/security-updates/update.py
+++ b/security-updates/update.py
@@ -95,9 +95,16 @@ class Advisory:
     severity: str
 
     def markdown_link(self) -> str:
+        # Prefer the GHSA advisory page: it always exists for a Dependabot
+        # alert, whereas a freshly-assigned CVE is often still RESERVED and
+        # returns "CVE ID Not Found" on NVD. Show the CVE as the link text
+        # when we have one, since it's the more familiar identifier.
+        if self.ghsa:
+            text = self.cve or self.ghsa
+            return f"[{text}](https://github.com/advisories/{self.ghsa})"
         if self.cve:
             return f"[{self.cve}](https://nvd.nist.gov/vuln/detail/{self.cve})"
-        return f"[{self.ghsa}](https://github.com/advisories/{self.ghsa})"
+        return "unknown advisory"
 
     def __str__(self) -> str:
         return f"{self.markdown_link()} ({self.severity}): {self.summary}"
@@ -142,10 +149,15 @@ def fetch_alerts(repo: str) -> list[VulnerablePackage]:
     )
     alerts = json.loads(raw)
 
-    # Group by package name
+    # Group by normalized package name. GitHub's advisory database reports
+    # the same package under inconsistent casing across advisories (e.g.
+    # "starlette" and "Starlette"); grouping by the raw name would split it
+    # into two packages, each with its own (lower) fix version, and the
+    # second upgrade would downgrade what the first one fixed.
     grouped: dict[str, VulnerablePackage] = {}
     for a in alerts:
         name = a["name"]
+        key = normalize_name(name)
         fixed = a.get("fixed")
         advisory = Advisory(
             ghsa=a.get("ghsa"),
@@ -153,16 +165,16 @@ def fetch_alerts(repo: str) -> list[VulnerablePackage]:
             summary=a["summary"],
             severity=a["severity"],
         )
-        if name not in grouped:
-            grouped[name] = VulnerablePackage(name=name, fixed=fixed)
+        if key not in grouped:
+            grouped[key] = VulnerablePackage(name=normalize_name(name), fixed=fixed)
         else:
             # Keep the highest fix version (None means no known fix)
             if fixed and (
-                grouped[name].fixed is None
-                or parse_version(fixed) > parse_version(grouped[name].fixed)
+                grouped[key].fixed is None
+                or parse_version(fixed) > parse_version(grouped[key].fixed)
             ):
-                grouped[name].fixed = fixed
-        grouped[name].advisories.append(advisory)
+                grouped[key].fixed = fixed
+        grouped[key].advisories.append(advisory)
 
     return list(grouped.values())
 


### PR DESCRIPTION
## Problem

Investigated odd output from the security workflow in [python-template#90](https://github.com/Komorebi-AI/python-template/pull/90). Two independent bugs:

### 1. Casing → split grouping → upgrade-then-downgrade (security correctness)

`fetch_alerts()` grouped Dependabot alerts by the **raw** package name. GitHub's advisory database reports the same package under inconsistent casing across advisories (e.g. `starlette` and `Starlette`), so it split into two `VulnerablePackage` entries with different fix versions:

- `starlette` (3 CVEs) → fix `1.3.1`
- `Starlette` (1 CVE) → fix `1.3.0`

`upgrade_packages()` then processed both sequentially: upgraded to `1.3.1`, then **downgraded to `1.3.0`**. The lockfile ended on `1.3.0`, leaving the three `1.3.1` CVEs unfixed even though the PR claimed to address them — plus two confusingly-cased rows.

### 2. Broken vulnerability links

`Advisory.markdown_link()` preferred NVD CVE links. Freshly-assigned `CVE-2026-*` ids are still RESERVED and return "CVE ID Not Found" on NVD, so the links were dead.

## Fix

- Group alerts by the PEP 503 **normalized** name so all advisories for a package merge and the highest fix version wins (`1.3.1`). Single upgrade, single row, lockfile lands on the correct fixed version.
- Prefer the GHSA advisory URL (always exists for a Dependabot alert) over NVD, showing the CVE id as the link text when present.

Verified both changes with an inline test against the real functions.

https://claude.ai/code/session_01VFS7dXstJqCtX4zYF9Gp3x