### PR TITLE
chore: add Dependabot for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Dependabot configuration
+# See https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Keep GitHub Actions used in the reusable workflows and composite actions up to date
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/" # .github/workflows/*
+      - "/security-updates" # composite action.yml
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adds a Dependabot config so the GitHub Actions used in this repo's reusable workflows and composite actions get weekly update PRs.

## Coverage
- `/` → the reusable workflows under `.github/workflows/` (`checkout`, `setup-uv`, `action-tmate`, `ssh-agent`, `codecov-action`, `pre-commit/action`, `prek-action`, …)
- `/security-updates` → the composite `action.yml` (`create-github-app-token`, `setup-uv`)

## Notes
Many of these actions are version-pinned (e.g. `astral-sh/setup-uv@v7`), so Dependabot will open PRs as new releases land. This keeps consumers of these reusable workflows on current, reviewed action versions.

https://claude.ai/code/session_013tXNtH8ospn9fWdNSardMs